### PR TITLE
How to import paired end illumina fastqs

### DIFF
--- a/scripts/01_import.sh
+++ b/scripts/01_import.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
 set -e
+NETID="$1"
+echo ${NETID}
 
 echo "Container launched successfully..."
 
 echo "Importing with QIIME tools import..."
-qiime tools import \
- --type 'SampleData[PairedEndSequencesWithQuality]' \
- --input-path fq-manifest.tsv \
- --output-path demux.qza \
- --input-format PairedEndFastqManifestPhred33V2
+qiime tools import --type 'SampleData[PairedEndSequencesWithQuality]' \
+  --input-path  /staging/${NETID}/seqs
+  --input-format CasavaOneEightSingleLanePerSampleDirFmt \
+  --output-path demux.qza
 
 echo "Running QIIME summarize..."
 qiime demux summarize \

--- a/scripts/01_import.sub
+++ b/scripts/01_import.sub
@@ -5,9 +5,7 @@ container_image = docker://quay.io/qiime2/amplicon:2025.4
 executable = 01_import.sh
 staging_path = file:///staging/$(netid)/input_outputs
 
-#state path to input files
-transfer_input_files = \
-  $(staging_path)/00_pipeline_inputs/fq-manifest.tsv
+arguments = $(netid)
 
 #state the output files
 transfer_output_files = demux.qza, demux.qzv


### PR DESCRIPTION
If the FASTQ files are located in `/staging/netid/seqs` in the following format:
Example folder format:
```
/staging/netid/seqs/
/staging/netid/seqs/sample1_R1_001.fastq.gz
/staging/netid/seqs/sample1_R2_001.fastq.gz
/staging/netid/seqs/sample2_R1_001.fastq.gz
/staging/netid/seqs/sample2_R2_001.fastq.gz
/staging/netid/seqs/sample3_R1_001.fastq.gz
/staging/netid/seqs/sample3_R2_001.fastq.gz
```

Then we don't need to specify a` tranfer_input_files `in the submit file.
We can directly use the `qiime2 import` function within the .sh script to import and create the qza file.

Please test this. Thanks!